### PR TITLE
Add support for relative paths in `Open`

### DIFF
--- a/goaseprite.go
+++ b/goaseprite.go
@@ -235,7 +235,12 @@ func Open(jsonPath string) *File {
 	}
 
 	asf := Read(fileData)
+
 	asf.Path = jsonPath
+	// fix imagePath when using relative paths
+	dir := filepath.Dir(jsonPath)
+	asf.ImagePath = dir + "/" + asf.ImagePath
+
 	return asf
 
 }


### PR DESCRIPTION
This is just a simple fix to allow nesting files in a resource folder, like this:
![image](https://user-images.githubusercontent.com/11507599/130948552-3a0c3e63-47e9-4187-b1ec-a6c472decac0.png)

And calling `Open` like this: `goaseprite.Open("assets/player.json")`.

### A bit more context
When the aseprite json has `meta.image = player.png`, and the `.go` file executing the `goaseprite.Open()` call is in another folder, the path to the png is incorrect.

This PR addresses this by parsing the folder path and "correcting" `imagePath`.

This means that `goaseprite.Open("assets/player.json")` now works as expected:

Small concern here, but I tested it and it works fine: `filepath.Dir` behaves nicely when there's no folder in the path, it just returns a `.`, which means that we get `./player.png` for example, and it's all good :)
